### PR TITLE
Fix tests for LocalCache

### DIFF
--- a/scripts/browse.py
+++ b/scripts/browse.py
@@ -1,0 +1,1 @@
+from autogpt.browse import *

--- a/tests/local_cache_test.py
+++ b/tests/local_cache_test.py
@@ -1,7 +1,8 @@
 import os
 import sys
+import unittest
 
-from autogpt.memory.local import LocalCache
+from autogpt.memory.local import EMBED_DIM, LocalCache
 
 
 def MockConfig():
@@ -29,7 +30,10 @@ class TestLocalCache(unittest.TestCase):
 
     def test_clear(self):
         self.cache.clear()
-        self.assertEqual(self.cache.data, [""])
+        self.assertEqual(self.cache.data.texts, [])
+        self.assertEqual(self.cache.data.embeddings.shape[0], 0)
+        # Optionally ensure embedding dimension is correct
+        self.assertEqual(self.cache.data.embeddings.shape[1], EMBED_DIM)
 
     def test_get(self):
         text = "Sample text"


### PR DESCRIPTION
## Summary
- add missing unittest import
- validate LocalCache.clear results
- re-export browse functions for tests

## Testing
- `pytest tests/local_cache_test.py tests/test_config.py tests/test_json_parser.py tests/unit/test_browse_scrape_links.py tests/unit/test_browse_scrape_text.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6869dae538dc832091536e5457e1ce13